### PR TITLE
Fixed bracket property accessor in sample JavaScript code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ var koopa = require('koopa');
 
 //presumably some kind of HTTP request handler
 function handleRequest(request) {
-  var userAgent = request.headers\['User-Agent'\];
+  var userAgent = request.headers['User-Agent'];
   var info = koopa(userAgent);
   if (info.ie && info.version.major < 9) {
     console.log('You suck!');


### PR DESCRIPTION
JavaScript doesn't need the angle brackets escaped with single quotes. Fixed that for you.
